### PR TITLE
update settings for django-compressor

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -228,7 +228,7 @@ COMPRESS_PRECOMPILERS = (
    ('text/less', 'lessc {infile} {outfile}'),
 )
 # needed for debug mode
-INTERNAL_IPS = ('127.0.0.1',)
+#INTERNAL_IPS = ('127.0.0.1',)
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to


### PR DESCRIPTION
add necessary settings for `django-compressor` to work in `DEBUG` mode
commented settings for `django-compressor` to work in `DEBUG=False` mode
removed settings for `django-assets`
